### PR TITLE
    feat: allow specifying gas parameters for transactions

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -9,7 +9,6 @@ use alloy::network::TransactionBuilder;
 use alloy::primitives::{Address, TxKind, address};
 use alloy::providers::Provider;
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
-use alloy_rlp::Encodable;
 use alloy_sol_types::sol;
 use displaydoc::Display;
 use thiserror::Error;
@@ -46,10 +45,8 @@ pub enum Error {
     TransactionSendError(String),
     /// Failed to get transaction receipt: {0}
     TransactionReceiptError(String),
-    /// Failed to decode expiration block: {0}
-    ExpirationBlockDecodeError(String),
-    /// Unexpected log data format
-    UnexpectedLogDataError,
+    /// Unexpected log data: {0}
+    UnexpectedLogDataError(String),
 }
 
 /// The Ethereum address of the GolemBase storage contract.
@@ -59,27 +56,19 @@ pub const STORAGE_ADDRESS: Address = address!("0x0000000000000000000000000000000
 impl GolemBaseClient {
     pub async fn send_transaction(
         &self,
-        creates: Vec<Create>,
-        updates: Vec<Update>,
-        deletes: Vec<Hash>,
-        extensions: Vec<Extend>,
+        tx: GolemBaseTransaction,
     ) -> Result<TransactionResult, Error> {
-        let receipt = self
-            .create_raw_transaction(GolemBaseTransaction {
-                creates,
-                updates,
-                deletes,
-                extensions,
-            })
-            .await?;
-
+        let receipt = self.create_raw_transaction(tx).await?;
         receipt.try_into()
     }
 
     /// Creates one or more new entities in GolemBase and returns their results.
     /// Sends a transaction to the storage contract and parses the resulting logs.
     pub async fn create_entities(&self, creates: Vec<Create>) -> Result<Vec<EntityResult>, Error> {
-        let result = self.send_transaction(creates, vec![], vec![], vec![]).await;
+        let result = self
+            .send_transaction(GolemBaseTransaction::builder().creates(creates).build())
+            .await;
+
         result.and_then(|res| match res {
             TransactionResult {
                 creates,
@@ -87,7 +76,7 @@ impl GolemBaseClient {
                 deletes,
                 extensions,
             } if updates.is_empty() && deletes.is_empty() && extensions.is_empty() => Ok(creates),
-            _ => Err(Error::TransactionReceiptError(
+            _ => Err(Error::UnexpectedLogDataError(
                 "Unexpected content in tx logs, this should never happen!".to_string(),
             )),
         })
@@ -96,7 +85,10 @@ impl GolemBaseClient {
     /// Updates one or more entities in GolemBase and returns their results.
     /// Sends a transaction to the storage contract and parses the resulting logs.
     pub async fn update_entities(&self, updates: Vec<Update>) -> Result<Vec<EntityResult>, Error> {
-        let result = self.send_transaction(vec![], updates, vec![], vec![]).await;
+        let result = self
+            .send_transaction(GolemBaseTransaction::builder().updates(updates).build())
+            .await;
+
         result.and_then(|res| match res {
             TransactionResult {
                 creates,
@@ -104,7 +96,7 @@ impl GolemBaseClient {
                 deletes,
                 extensions,
             } if creates.is_empty() && deletes.is_empty() && extensions.is_empty() => Ok(updates),
-            _ => Err(Error::TransactionReceiptError(
+            _ => Err(Error::UnexpectedLogDataError(
                 "Unexpected content in tx logs, this should never happen!".to_string(),
             )),
         })
@@ -113,7 +105,10 @@ impl GolemBaseClient {
     /// Deletes one or more entities in GolemBase and returns their results.
     /// Sends a transaction to the storage contract and parses the resulting logs.
     pub async fn delete_entities(&self, deletes: Vec<Hash>) -> Result<Vec<DeleteResult>, Error> {
-        let result = self.send_transaction(vec![], vec![], deletes, vec![]).await;
+        let result = self
+            .send_transaction(GolemBaseTransaction::builder().deletes(deletes).build())
+            .await;
+
         result.and_then(|res| match res {
             TransactionResult {
                 creates,
@@ -121,7 +116,7 @@ impl GolemBaseClient {
                 deletes,
                 extensions,
             } if creates.is_empty() && updates.is_empty() && extensions.is_empty() => Ok(deletes),
-            _ => Err(Error::TransactionReceiptError(
+            _ => Err(Error::UnexpectedLogDataError(
                 "Unexpected content in tx logs, this should never happen!".to_string(),
             )),
         })
@@ -134,8 +129,13 @@ impl GolemBaseClient {
         extensions: Vec<Extend>,
     ) -> Result<Vec<ExtendResult>, Error> {
         let result = self
-            .send_transaction(vec![], vec![], vec![], extensions)
+            .send_transaction(
+                GolemBaseTransaction::builder()
+                    .extensions(extensions)
+                    .build(),
+            )
             .await;
+
         result.and_then(|res| match res {
             TransactionResult {
                 creates,
@@ -143,48 +143,50 @@ impl GolemBaseClient {
                 deletes,
                 extensions,
             } if creates.is_empty() && updates.is_empty() && deletes.is_empty() => Ok(extensions),
-            _ => Err(Error::TransactionReceiptError(
+            _ => Err(Error::UnexpectedLogDataError(
                 "Unexpected content in tx logs, this should never happen!".to_string(),
             )),
         })
     }
 
-    /// Creates and sends a raw transaction to the GolemBase storage contract.
-    /// Encodes the transaction payload and sends it to the contract address.
-    ///
     /// NOTE: Nonce management is tricky!
     /// - This implementation always tries to fetch the latest on-chain nonce before sending a transaction,
     ///   and only falls back to the locally cached base_nonce if the sync fails.
     /// - Only the number of in-flight transactions is tracked locally.
     /// - For robust production use, consider also handling stuck transactions (e.g., gas bumping/EIP-1559).
+    async fn next_nonce(&self) -> u64 {
+        // This is sadly needed because `self.provider.get_transaction_count(self.wallet.address()).pending()`
+        // doesn't give the right number...
+        //
+        //      Error: server returned an error response: error code -32000: replacement transaction underpriced
+        let mut nm = self.nonce_manager.lock().await;
+        let wallet_address = self.wallet.address();
+        match self.provider.get_transaction_count(wallet_address).await {
+            Ok(on_chain_nonce) => {
+                nm.base_nonce = on_chain_nonce;
+            }
+            Err(e) => {
+                log::warn!("Failed to fetch on-chain nonce: {}", e);
+            }
+        }
+        nm.next_nonce().await
+    }
+
+    /// Creates and sends a raw transaction to the GolemBase storage contract.
+    /// Encodes the transaction payload and sends it to the contract address.
     pub async fn create_raw_transaction(
         &self,
         payload: GolemBaseTransaction,
     ) -> Result<TransactionReceipt, Error> {
         log::debug!("payload: {:?}", payload);
-        let mut buffer = Vec::new();
-        payload.encode(&mut buffer);
-        log::debug!("buffer: {:?}", buffer);
-        let nonce = {
-            // This is sadly needed because `self.provider.get_transaction_count(self.wallet.address()).pending()`
-            // doesn't give the right number...
-            //
-            //      Error: server returned an error response: error code -32000: replacement transaction underpriced
-            let mut nm = self.nonce_manager.lock().await;
-            let wallet_address = self.wallet.address();
-            match self.provider.get_transaction_count(wallet_address).await {
-                Ok(on_chain_nonce) => {
-                    nm.base_nonce = on_chain_nonce;
-                }
-                Err(e) => {
-                    log::warn!("Failed to fetch on-chain nonce: {}", e);
-                }
-            }
-            nm.next_nonce().await
-        };
-        let tx_base = TransactionRequest {
+        let encoded = payload.encoded();
+        log::debug!("buffer: {:?}", encoded);
+
+        let nonce = self.next_nonce().await;
+
+        let mut tx = TransactionRequest {
             to: Some(TxKind::Call(STORAGE_ADDRESS)),
-            input: buffer.into(),
+            input: encoded.into(),
             chain_id: Some(
                 self.provider
                     .get_chain_id()
@@ -194,21 +196,28 @@ impl GolemBaseClient {
             nonce: Some(nonce),
             ..Default::default()
         };
-        log::debug!("transaction: {:?}", tx_base);
-        let estimated_gas = self
-            .provider
-            .estimate_gas(tx_base.clone())
-            .await
-            .map_err(|e| Error::TransactionSendError(format!("Failed to estimate gas: {}", e)))?;
-        let tx = tx_base.with_gas_limit(estimated_gas).with_gas_price(
-            self.provider
-                .get_gas_price()
-                .await
-                .map_err(|e| Error::TransactionSendError(e.to_string()))?,
-        );
+        log::debug!("transaction: {:?}", tx);
+
+        let gas_limit = if let Some(gas_limit) = payload.gas_limit {
+            gas_limit
+        } else {
+            self.provider.estimate_gas(tx.clone()).await.map_err(|e| {
+                Error::TransactionSendError(format!("Failed to estimate gas: {}", e))
+            })?
+        };
+        tx = tx.with_gas_limit(gas_limit);
+
+        if let Some(max_fee_per_gas) = payload.max_fee_per_gas {
+            tx = tx.with_max_fee_per_gas(max_fee_per_gas);
+        }
+
+        if let Some(max_priority_fee_per_gas) = payload.max_priority_fee_per_gas {
+            tx = tx.with_max_priority_fee_per_gas(max_priority_fee_per_gas);
+        }
+
         let pending_tx = self
             .provider
-            .send_transaction(tx)
+            .send_transaction(tx.clone())
             .await
             .map_err(|e| Error::TransactionSendError(e.to_string()))?;
         log::debug!("pending transaction: {:?}", pending_tx);
@@ -221,6 +230,13 @@ impl GolemBaseClient {
             let mut nm = self.nonce_manager.lock().await;
             nm.complete().await;
         }
+
+        if !receipt.status() {
+            self.provider.call(tx).await.map_err(|e| {
+                Error::TransactionReceiptError(format!("Error during tx execution: {e}"))
+            })?;
+        }
+
         Ok(receipt)
     }
 }


### PR DESCRIPTION
Also replay transactions with eth_call when an explicit gas price was specified so that we get a descriptive error message from the RPC call.
Without an explicit gas price, we already get this error message from the estimate_gas call.
