### PR TITLE
Use tracing for async logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,6 @@ dependencies = [
  "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ipc",
  "alloy-transport-ws",
 ]
 
@@ -203,7 +202,6 @@ checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "k256",
  "serde",
  "thiserror 2.0.15",
 ]
@@ -350,16 +348,11 @@ dependencies = [
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types-anvil",
- "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
- "alloy-rpc-types-txpool",
  "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ipc",
  "alloy-transport-ws",
  "async-stream",
  "async-trait",
@@ -436,7 +429,6 @@ dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ipc",
  "alloy-transport-ws",
  "futures",
  "pin-project",
@@ -458,23 +450,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41492dac39365b86a954de86c47ec23dcc7452cdb2fde591caadc194b3e34c6"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-anvil",
- "alloy-rpc-types-debug",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
- "alloy-rpc-types-txpool",
- "alloy-serde",
- "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-anvil"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10493fa300a2757d8134f584800fef545c15905c95122bed1f6dde0b0d9dae27"
-dependencies = [
- "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -489,34 +464,6 @@ dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-debug"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b6f0482c82310366ec3dcf4e5212242f256a69fcf1a26e5017e6704091ee95"
-dependencies = [
- "alloy-primitives",
- "derive_more",
- "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-engine"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24c171377c0684e3860385f6d93fbfcc8ecc74f6cce8304c822bf1a50bacce0"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more",
- "rand 0.8.5",
- "serde",
- "strum",
 ]
 
 [[package]]
@@ -538,32 +485,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror 2.0.15",
-]
-
-[[package]]
-name = "alloy-rpc-types-trace"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a854af3fe8fce1cfe319fcf84ee8ba8cda352b14d3dd4221405b5fc6cce9e1"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "serde",
- "serde_json",
- "thiserror 2.0.15",
-]
-
-[[package]]
-name = "alloy-rpc-types-txpool"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc803e9b8d16154c856a738c376e002abe4b388e5fef91c8aebc8373e99fd45"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "serde",
 ]
 
 [[package]]
@@ -722,26 +643,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-transport-ipc"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79064b5a08259581cb5614580010007c2df6deab1e8f3e8c7af8d7e9227008f"
-dependencies = [
- "alloy-json-rpc",
- "alloy-pubsub",
- "alloy-transport",
- "bytes",
- "futures",
- "interprocess",
- "pin-project",
- "serde",
- "serde_json",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "alloy-transport-ws"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,56 +702,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "anstream"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
-dependencies = [
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1281,52 +1132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.5.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
 name = "const-hex"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,12 +1449,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doctest-file"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,29 +1502,6 @@ dependencies = [
  "serdect",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -2010,19 +1786,16 @@ dependencies = [
  "bigdecimal",
  "bon",
  "bytes",
- "clap",
  "dirs",
  "displaydoc",
- "env_logger",
  "futures",
  "golem-base-test-utils",
  "hex",
- "log",
  "serde",
- "serde_json",
  "serial_test",
  "thiserror 2.0.15",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -2031,11 +1804,11 @@ name = "golem-base-sdk-demo"
 version = "0.1.0"
 dependencies = [
  "dirs",
- "env_logger",
  "futures",
  "golem-base-sdk",
- "log",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2046,9 +1819,9 @@ dependencies = [
  "anyhow",
  "bigdecimal",
  "dirs",
- "env_logger",
  "golem-base-sdk",
- "log",
+ "tracing",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -2414,21 +2187,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interprocess"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d941b405bd2322993887859a8ee6ac9134945a24ec5ec763a8a962fc64dfec2d"
-dependencies = [
- "doctest-file",
- "futures-core",
- "libc",
- "recvmsg",
- "tokio",
- "widestring",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "io-uring"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,12 +2214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,30 +2236,6 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "jiff"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
 
 [[package]]
 name = "js-sys"
@@ -2629,6 +2357,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2669,6 +2406,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -2767,12 +2514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-
-[[package]]
 name = "openssl"
 version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2821,6 +2562,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
@@ -2964,21 +2711,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "portable-atomic"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3077,7 +2809,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -3182,12 +2914,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "recvmsg"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,8 +2961,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -3247,8 +2982,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3784,19 +3525,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "signature"
@@ -4002,6 +3743,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4071,9 +3821,7 @@ dependencies = [
  "io-uring",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "slab",
  "socket2",
  "tokio-macros",
@@ -4243,6 +3991,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4340,12 +4118,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -4522,10 +4294,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "1.2.0"
+name = "winapi"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,10 @@ resolver = "2"
 
 # This is available as a feature in the alloy crate, however,
 # the macro expansion is broken as it doesn't rexport the crate
-# name correctly and references `alloy_rlp` directly. Once this
-# is fixed, this can be removed and "rlp" can be added to features.
+# name correctly and references `alloy_rlp` directly. It doesn't
+# seem that they plan to fix it, so this must be locked at the
+# version found in the Cargo.toml of the alloy crate to maintain
+# compatibility.
 # 
 # https://github.com/alloy-rs/rlp/issues/40
 [dependencies.alloy-rlp]
@@ -34,10 +36,10 @@ dirs = "6.0"
 displaydoc = "0.2"
 futures = "0.3"
 hex = "0.4"
-log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
-tokio = { version = "1.45", features = ["full"] }
+tokio = { version = "1.45", features = ["macros", "rt-multi-thread"] }
+tracing = { version = "0.1" }
 url = "2.5"
 
 [workspace.dependencies]
@@ -45,9 +47,5 @@ golem-base-sdk = { path = "." }
 golem-base-test-utils = { path = "test-utils" }
 
 [dev-dependencies]
-clap = { version = "4.5", features = ["derive"] }
-env_logger = "0.11"
-serde_json = "1.0"
 serial_test = "3.2"
-
 golem-base-test-utils = { workspace = true }

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "golem-base-sdk-demo"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 dirs = "6.0"
-env_logger = "0.11"
 futures = "0.3"
 golem-base-sdk = { workspace = true }
-log = "0.4"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -7,7 +7,7 @@ use golem_base_sdk::events::EventsClient;
 use golem_base_sdk::{
     Address, Annotation, GolemBaseClient, GolemBaseRoClient, PrivateKeySigner, Url,
 };
-use log::info;
+use tracing::info;
 
 async fn log_num_of_entities_owned(client: &GolemBaseRoClient, owner_address: Address) {
     let n = client
@@ -20,7 +20,12 @@ async fn log_num_of_entities_owned(client: &GolemBaseRoClient, owner_address: Ad
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(std::io::stdout)
+        .pretty()
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("Could not set up global logger");
 
     let keypath = config_dir()
         .ok_or("Failed to get config directory")?

--- a/src/eth.rs
+++ b/src/eth.rs
@@ -164,7 +164,7 @@ impl GolemBaseClient {
                 nm.base_nonce = on_chain_nonce;
             }
             Err(e) => {
-                log::warn!("Failed to fetch on-chain nonce: {e}");
+                tracing::warn!("Failed to fetch on-chain nonce: {e}");
             }
         }
         nm.next_nonce().await
@@ -176,9 +176,9 @@ impl GolemBaseClient {
         &self,
         payload: GolemBaseTransaction,
     ) -> Result<TransactionReceipt, Error> {
-        log::debug!("payload: {payload:?}");
+        tracing::debug!("payload: {payload:?}");
         let encoded = payload.encoded();
-        log::debug!("buffer: {encoded:?}");
+        tracing::debug!("buffer: {encoded:?}");
 
         let nonce = self.next_nonce().await;
 
@@ -194,7 +194,7 @@ impl GolemBaseClient {
             nonce: Some(nonce),
             ..Default::default()
         };
-        log::debug!("transaction: {tx:?}");
+        tracing::debug!("transaction: {tx:?}");
 
         let gas_limit = if let Some(gas_limit) = payload.gas_limit {
             gas_limit
@@ -219,12 +219,12 @@ impl GolemBaseClient {
             .send_transaction(tx.clone())
             .await
             .map_err(|e| Error::TransactionSendError(e.to_string()))?;
-        log::debug!("pending transaction: {pending_tx:?}");
+        tracing::debug!("pending transaction: {pending_tx:?}");
         let receipt = pending_tx
             .get_receipt()
             .await
             .map_err(|e| Error::TransactionReceiptError(e.to_string()))?;
-        log::debug!("receipt: {receipt:?}");
+        tracing::debug!("receipt: {receipt:?}");
         {
             let mut nm = self.nonce_manager.lock().await;
             nm.complete().await;

--- a/src/events.rs
+++ b/src/events.rs
@@ -126,14 +126,14 @@ impl EventsClient {
     /// Creates a new `EventsClient` by connecting to the given websocket `Url`.
     /// Establishes a connection to the blockchain node for event streaming.
     pub async fn new(url: Url) -> anyhow::Result<Self> {
-        log::debug!("Connecting to websocket provider: {url}");
+        tracing::debug!("Connecting to websocket provider: {url}");
 
         let provider = ProviderBuilder::new()
             .connect_ws(WsConnect::new(url.clone()))
             .await?
             .erased();
 
-        log::info!("Connected to websocket provider: {url}");
+        tracing::info!("Connected to websocket provider: {url}");
         Ok(Self { provider })
     }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -85,12 +85,12 @@ impl GolemBaseRoClient {
         params: S,
     ) -> Result<R, Error> {
         let method = method.into();
-        log::debug!("RPC Call - Method: {method}, Params: {params:?}");
+        tracing::debug!("RPC Call - Method: {method}, Params: {params:?}");
         self.provider
             .client()
             .request(method.clone(), params)
             .await
-            .inspect(|res| log::debug!("RPC Response: {res:?}"))
+            .inspect(|res| tracing::debug!("RPC Response: {res:?}"))
             .map_err(|e| match e {
                 RpcError::ErrorResp(err) => {
                     anyhow!("Error response from RPC service: {err}")
@@ -99,7 +99,7 @@ impl GolemBaseRoClient {
                     anyhow!("Serialization error: {err}")
                 }
                 RpcError::DeserError { err, text } => {
-                    log::debug!("Deserialization error: {err}, response text: {text}");
+                    tracing::debug!("Deserialization error: {err}, response text: {text}");
                     anyhow!("Deserialization error: {err}")
                 }
                 _ => anyhow!("{e}"),

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -4,12 +4,15 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-alloy = { version = "1.0.24", features = ["full", "json-rpc"] }
+alloy = { version = "1.0.24", features = [
+  "provider-ws",
+  "json-rpc",
+  "signer-keystore",
+] }
 anyhow = "1.0"
 bigdecimal = "0.4"
-env_logger = "0.11.8"
-log = "0.4"
-
 dirs = "6.0.0"
 golem-base-sdk = { workspace = true }
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2.5.4"

--- a/tests/test_entity_operations.rs
+++ b/tests/test_entity_operations.rs
@@ -13,7 +13,7 @@ async fn test_create_and_retrieve_entry() -> Result<()> {
     let client = get_client()?;
 
     let start_block = client.get_current_block_number().await?;
-    log::info!("Starting at block: {start_block}");
+    tracing::info!("Starting at block: {start_block}");
 
     let test_payload = b"test payload".to_vec();
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
@@ -24,16 +24,16 @@ async fn test_create_and_retrieve_entry() -> Result<()> {
 
     let tx_results = client.create_entities(vec![create_tx]).await?;
     let entity_result = &tx_results[0];
-    log::info!("Entry created with ID: {entity_result:?}");
+    tracing::info!("Entry created with ID: {entity_result:?}");
 
     let entry_str = client
         .get_storage_value::<Bytes>(entity_result.entity_key)
         .await?;
-    log::info!("Retrieved value: {entry_str:?}");
+    tracing::info!("Retrieved value: {entry_str:?}");
     assert_eq!(entry_str, String::from_utf8(test_payload)?);
 
     let metadata = client.get_entity_metadata(entity_result.entity_key).await?;
-    log::info!("Retrieved metadata: {metadata:?}");
+    tracing::info!("Retrieved metadata: {metadata:?}");
 
     assert_eq!(metadata.string_annotations[0].value, "Test");
     assert_eq!(metadata.numeric_annotations[0].value, timestamp);
@@ -57,7 +57,7 @@ async fn test_entity_operations() -> Result<()> {
 
     let tx1_results = client.create_entities(vec![create1]).await?;
     let entity1_result = &tx1_results[0];
-    log::info!("Entry created with ID: {entity1_result:?}");
+    tracing::info!("Entry created with ID: {entity1_result:?}");
 
     // Create second entity
     let payload2 = b"second entity".to_vec();
@@ -68,7 +68,7 @@ async fn test_entity_operations() -> Result<()> {
 
     let tx2_results = client.create_entities(vec![create2]).await?;
     let entity2_result = &tx2_results[0];
-    log::info!("Entry created with ID: {entity1_result:?}");
+    tracing::info!("Entry created with ID: {entity1_result:?}");
 
     // Verify both entities exist
     let entity1_str = String::from_utf8(
@@ -85,8 +85,8 @@ async fn test_entity_operations() -> Result<()> {
             .to_vec(),
     )
     .unwrap();
-    log::info!("Retrieved first entry: {entity1_str}");
-    log::info!("Retrieved second entry: {entity2_str}");
+    tracing::info!("Retrieved first entry: {entity1_str}");
+    tracing::info!("Retrieved second entry: {entity2_str}");
     assert_eq!(entity1_str, String::from_utf8(payload1)?);
     assert_eq!(entity2_str, String::from_utf8(payload2)?);
 
@@ -98,7 +98,7 @@ async fn test_entity_operations() -> Result<()> {
         .annotate_number("test_timestamp", updated_timestamp);
 
     client.update_entities(vec![update]).await?;
-    log::info!("First entry updated");
+    tracing::info!("First entry updated");
 
     // Verify first entity was updated
     let updated_str = String::from_utf8(
@@ -107,14 +107,14 @@ async fn test_entity_operations() -> Result<()> {
             .await?,
     )
     .unwrap();
-    log::info!("Retrieved updated first entry: {updated_str}");
+    tracing::info!("Retrieved updated first entry: {updated_str}");
     assert_eq!(updated_str, String::from_utf8(updated_payload.clone())?);
 
     // Remove second entity
     client
         .delete_entities(vec![entity2_result.entity_key])
         .await?;
-    log::info!("Second entry removed");
+    tracing::info!("Second entry removed");
 
     // Verify second entity was removed
     let result = client.get_entity_metadata(entity2_result.entity_key).await;
@@ -133,7 +133,7 @@ async fn test_entity_operations() -> Result<()> {
             .to_vec(),
     )
     .unwrap();
-    log::info!("Retrieved final first entry: {final_str}");
+    tracing::info!("Retrieved final first entry: {final_str}");
     assert_eq!(final_str, String::from_utf8(updated_payload)?);
 
     Ok(())
@@ -214,7 +214,7 @@ async fn test_concurrent_entity_creation_batch() -> Result<()> {
         assert_eq!(metadata.numeric_annotations[0].value, i as u64);
     }
 
-    log::info!(
+    tracing::info!(
         "Successfully verified {} concurrent batch entity creations",
         ENTITIES_PER_TASK * 2
     );
@@ -227,7 +227,7 @@ async fn test_failed_tx_explicit_gas() -> Result<()> {
     let client = get_client()?;
 
     let start_block = client.get_current_block_number().await?;
-    log::info!("Starting at block: {start_block}");
+    tracing::info!("Starting at block: {start_block}");
 
     let create_tx = GolemBaseTransaction::builder()
         .extensions(vec![Extend::new(FixedBytes::with_last_byte(1), 1000)])

--- a/tests/test_query.rs
+++ b/tests/test_query.rs
@@ -25,42 +25,42 @@ async fn test_query_entities() -> Result<()> {
     {
         // Test queries
         let type_test_entries = client.query_entity_keys("type = \"test\"").await?;
-        log::info!("Entries with type = \"test\": {type_test_entries:?}");
+        tracing::info!("Entries with type = \"test\": {type_test_entries:?}");
         assert!(type_test_entries.contains(&entity1.entity_key));
         assert!(type_test_entries.contains(&entity2.entity_key));
 
         let category_alpha_entries = client.query_entity_keys("category = \"alpha\"").await?;
-        log::info!("Entries with category = \"alpha\": {category_alpha_entries:?}");
+        tracing::info!("Entries with category = \"alpha\": {category_alpha_entries:?}");
         assert!(category_alpha_entries.contains(&entity1.entity_key));
         assert!(category_alpha_entries.contains(&entity3.entity_key));
 
         let type_demo_entries = client.query_entity_keys("type = \"demo\"").await?;
-        log::info!("Entries with type = \"demo\": {type_demo_entries:?}");
+        tracing::info!("Entries with type = \"demo\": {type_demo_entries:?}");
         assert!(type_demo_entries.contains(&entity3.entity_key));
 
         let combined_and = client
             .query_entity_keys("type = \"test\" && category = \"beta\"")
             .await?;
-        log::info!("Entries with type = \"test\" && category = \"beta\": {combined_and:?}");
+        tracing::info!("Entries with type = \"test\" && category = \"beta\": {combined_and:?}");
         assert!(combined_and.contains(&entity2.entity_key));
 
         let combined_or = client
             .query_entity_keys("type = \"demo\" || category = \"beta\"")
             .await?;
-        log::info!("Entries with type = \"demo\" || category = \"beta\": {combined_or:?}");
+        tracing::info!("Entries with type = \"demo\" || category = \"beta\": {combined_or:?}");
         assert!(combined_or.contains(&entity2.entity_key));
         assert!(combined_or.contains(&entity3.entity_key));
 
         // Test empty result
         let no_results = client.query_entity_keys("type = \"nonexistent\"").await?;
-        log::info!("Entries with type = \"nonexistent\": {no_results:?}");
+        tracing::info!("Entries with type = \"nonexistent\": {no_results:?}");
         assert_eq!(no_results.len(), 0);
 
         // Test selecting all entries
         let all_entries = client
             .query_entity_keys("type = \"test\" || type = \"demo\"")
             .await?;
-        log::info!("All entries: {all_entries:?}");
+        tracing::info!("All entries: {all_entries:?}");
         assert!(all_entries.contains(&entity1.entity_key));
         assert!(all_entries.contains(&entity2.entity_key));
         assert!(all_entries.contains(&entity3.entity_key));


### PR DESCRIPTION
`log` and `env_logger` are synchronous logging crates, which tend to stall things a bit and potentially log in the wrong order. This updates those to async logging crates, and reduces some build times by only including the tokio features needed.