### PR TITLE
doc: Add usage to client and btl notes to relevant types

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -102,8 +102,9 @@
         checks = self.checks.${system};
         packages = with pkgs; [
           pre-commit
-          nil
           nixpkgs-fmt
+        ] ++ lib.optionals (!pkgs.stdenv.isDarwin) [
+          nil # currently requires compiling the world
         ];
       };
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -39,6 +39,29 @@ impl NonceManager {
 
 /// A client for interacting with the GolemBase system.
 /// Provides methods for account management, entity operations, balance queries, and event subscriptions.
+///
+/// # Example Usage
+///
+/// A client builder is provided for both [`GolemBaseClient`] and [`GolemBaseRoClient`],
+/// however, an instance of [`GolemBaseClient`] can be dereferenced to [`GolemBaseRoClient`] like so:
+///
+/// ```rs
+/// use golem_base_sdk::{GolemBaseClient, GolemBaseRoClient, PrivateKeySigner, Url};
+///
+/// let keypath = dirs::config_dir()
+///     .ok_or("Failed to get config directory")?
+///     .join("golembase")
+///     .join("wallet.json");
+/// let signer = PrivateKeySigner::decrypt_keystore(keypath, "password")?;
+/// let url = Url::parse("http://localhost:8545")?;
+///
+/// let client = GolemBaseClient::builder()
+///     .wallet(signer)
+///     .rpc_url(url)
+///     .build();
+///
+/// let ro_client: &GolemBaseRoClient = *client;
+/// ```
 #[derive(Clone)]
 pub struct GolemBaseRoClient {
     /// The underlying provider for making RPC calls.
@@ -63,6 +86,29 @@ impl GolemBaseRoClient {
 
 /// A client for interacting with the GolemBase system.
 /// Provides methods for account management, entity operations, balance queries, and event subscriptions.
+///
+/// # Example Usage
+///
+/// A client builder is provided for both [`GolemBaseClient`] and [`GolemBaseRoClient`],
+/// however, an instance of [`GolemBaseClient`] can be dereferenced to [`GolemBaseRoClient`] like so:
+///
+/// ```rs
+/// use golem_base_sdk::{GolemBaseClient, GolemBaseRoClient, PrivateKeySigner, Url};
+///
+/// let keypath = dirs::config_dir()
+///     .ok_or("Failed to get config directory")?
+///     .join("golembase")
+///     .join("wallet.json");
+/// let signer = PrivateKeySigner::decrypt_keystore(keypath, "password")?;
+/// let url = Url::parse("http://localhost:8545")?;
+///
+/// let client = GolemBaseClient::builder()
+///     .wallet(signer)
+///     .rpc_url(url)
+///     .build();
+///
+/// let ro_client: &GolemBaseRoClient = *client;
+/// ```
 #[derive(Clone)]
 pub struct GolemBaseClient {
     /// The underlying GolemBaseRoClient

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -48,6 +48,9 @@ pub type Key = String;
 
 /// Type representing a create transaction in GolemBase.
 /// Used to define new entities, including their data, BTL, and annotations.
+///
+/// > Note: Each block represents ~2 seconds, eg. setting the BTL (blocks-to-live) to
+/// > `15u64` is equal to 30 seconds of life for the entity.
 #[derive(Debug, Clone, Default, RlpEncodable, RlpDecodable, Deserialize)]
 #[rlp(trailing)]
 pub struct Create {
@@ -63,6 +66,9 @@ pub struct Create {
 
 /// Type representing an update transaction in GolemBase.
 /// Used to update existing entities, including their data, BTL, and annotations.
+///
+/// > Note: Each block represents ~2 seconds, eg. setting the BTL (blocks-to-live) to
+/// > `15u64` is equal to 30 seconds of life for the entity.
 #[derive(Debug, Clone, Default, RlpEncodable, RlpDecodable, Deserialize)]
 #[rlp(trailing)]
 pub struct Update {
@@ -83,6 +89,9 @@ pub type GolemBaseDelete = Hash;
 
 /// Type representing an extend transaction in GolemBase.
 /// Used to extend the BTL of an entity by a number of blocks.
+///
+/// > Note: Each block represents ~2 seconds, eg. setting the BTL (blocks-to-live) to
+/// > `15u64` is equal to 30 seconds of life for the entity.
 #[derive(Debug, Clone, Default, RlpEncodable, RlpDecodable, Deserialize)]
 pub struct Extend {
     /// The key of the entity to extend.
@@ -96,7 +105,6 @@ pub struct Extend {
 #[derive(Debug, Clone)]
 pub struct GolemBaseTransaction {
     pub encodable: EncodableGolemBaseTransaction,
-
     pub gas_limit: Option<u64>,
     pub max_priority_fee_per_gas: Option<u128>,
     pub max_fee_per_gas: Option<u128>,
@@ -117,6 +125,9 @@ pub struct EncodableGolemBaseTransaction {
 
 /// Represents an entity with data, BTL, and annotations.
 /// Used for reading entity state from the chain.
+///
+/// > Note: Each block represents ~2 seconds, eg. setting the BTL (blocks-to-live) to
+/// > `15u64` is equal to 30 seconds of life for the entity.
 #[derive(Debug, Clone, Default, RlpEncodable, RlpDecodable, Serialize, Deserialize)]
 pub struct Entity {
     /// The data associated with the entity.


### PR DESCRIPTION
Adds example usage to the client types, and explanation of BTL to entity types.